### PR TITLE
Validate license mapping, drop Iconclass subject migration

### DIFF
--- a/docs/datamodel/index.qmd
+++ b/docs/datamodel/index.qmd
@@ -38,8 +38,7 @@ DCMI Type Vocabulary for resource types:
 ### Subject (`subject`)
 Iconclass classification system for describing and indexing visual content. Iconclass organizes motifs, themes, and concepts through standardized codes for semantic interoperability.
 
-Example:
-- `11A|Deity, God (in general) in Christian religion`
+**Not used.** Classifying all records with Iconclass was dropped due to time and personnel restrictions (see issue #7). The list and the `hasSubjectList` property remain in the deployed ontology but are not populated; the migration does not write subject values and removes any left over from earlier runs.
 
 ### License (`license`)
 Standard licenses and rights statements:
@@ -89,7 +88,7 @@ The `SGB` ontology extends Dublin Core Terms (dcterms) and includes the followin
 - **hasRelation**: Related resources (e.g., HLS, Wikipedia, Wikidata)
 - **hasRights**: Rights information
 - **hasSource**: Provenance and processing (memory institution, call number, digitisation/provenance, editing notes)
-- **hasSubjectList**: Subject classification (linked to subject list)
+- **hasSubjectList**: Subject classification (linked to subject list; not populated — see Subject above)
 - **hasTemporalList**: Temporal period (linked to temporal list)
 - **hasTitle**: Title of the resource
 - **hasTypeList**: Resource type (linked to type list)

--- a/docs/guides/development.qmd
+++ b/docs/guides/development.qmd
@@ -296,9 +296,9 @@ def debug_item_processing(item):
 
     ``` python
     # Check property extraction
-    props = item.get("dcterms:subject", [])
-    subjects = extract_combined_values(props)
-    print(f"Extracted subjects: {subjects}")
+    props = item.get("dcterms:creator", [])
+    creators = extract_combined_values(props)
+    print(f"Extracted creators: {creators}")
     ```
 
 ### Debug Mode

--- a/docs/guides/installation.qmd
+++ b/docs/guides/installation.qmd
@@ -157,7 +157,7 @@ Your DSP project must have a compatible data model. The system expects:
 -   `hasDescription`: Resource description or abstract
 -   `hasCreator`: Creator information
 -   `hasDate`: Date information in EDTF format
--   `hasSubjectList`: Subject classifications (Iconclass list)
+-   `hasSubjectList`: Subject classifications (Iconclass list; present in the ontology but not populated — Iconclass classification was dropped for time and personnel reasons, see issue #7)
 -   `hasTypeList`: Resource type (DCMI list)
 -   `hasFormatList`: File format (Internet Media Type list)
 -   `hasLanguageList`: Language (ISO 639-1 list)

--- a/docs/workflows/index.qmd
+++ b/docs/workflows/index.qmd
@@ -234,13 +234,11 @@ flowchart TD
     F4 --> G
     F5 --> G
     
-    G --> G1[dcterms:subject → subject]
     G --> G2[dcterms:language → language]
     G --> G3[dcterms:rights → rights]
     G --> G4[dcterms:license → license]
     
-    G1 --> H[Map List Values]
-    G2 --> H
+    G2 --> H[Map List Values]
     G3 --> H
     G4 --> H
     

--- a/scripts/data_2_dasch.py
+++ b/scripts/data_2_dasch.py
@@ -73,16 +73,21 @@ def build_context() -> dict:
     }
 
 
-# Set up logging
-file_handler = logging.FileHandler("data_2_dasch.log", mode="w")
-file_handler.setLevel(logging.INFO)
-stream_handler = logging.StreamHandler()
-stream_handler.setLevel(logging.INFO)
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[stream_handler, file_handler],
-)
+def setup_logging() -> None:
+    """Log to stdout and a fresh data_2_dasch.log.
+
+    Called from main() rather than at import time so that importing this module
+    (tests, remove_subject_values.py) does not truncate the migration log.
+    """
+    file_handler = logging.FileHandler("data_2_dasch.log", mode="w")
+    file_handler.setLevel(logging.INFO)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.INFO)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[stream_handler, file_handler],
+    )
 
 
 def parse_arguments() -> Namespace:
@@ -996,7 +1001,7 @@ def sync_existing(token, resource_iri, source, lists, label, kind):
 
 
 def main() -> None:
-
+    setup_logging()
     args = parse_arguments()
 
     # Fetch item data

--- a/scripts/data_2_dasch.py
+++ b/scripts/data_2_dasch.py
@@ -7,7 +7,7 @@ import urllib.parse
 import zipfile
 from argparse import Namespace
 from pathlib import Path
-from typing import Any, Dict, List, cast
+from typing import cast
 
 import requests
 from process_data_from_omeka import (
@@ -39,15 +39,6 @@ DEFAULT_TIMEOUT = 30
 NUMBER_RANDOM_OBJECTS = 2
 TEST_DATA = {"abb13025", "abb14375", "abb41033", "abb11536", "abb28998"}
 
-ICONCLASS_SUBJECT_ENTRY = {
-    "type": "literal",
-    "property_id": 3,
-    "property_label": "Subject",
-    "is_public": True,
-    "@value": "11A|Deity, God (in general) in Christian religion",
-    "@language": "en",
-}
-
 ONTOLOGY_CONTEXT = (
     f"{API_HOST}/ontology/{PROJECT_SHORT_CODE}/{ONTOLOGY_NAME}/v2#"
     if all([API_HOST, PROJECT_SHORT_CODE, ONTOLOGY_NAME])
@@ -60,8 +51,11 @@ MEDIA_RESOURCE_TYPES = {
     f"{PREFIX}ResourceWithoutMedia",
 }
 
+# dcterms:subject is deliberately not migrated: classifying all records with
+# Iconclass was dropped for time and personnel reasons (issue #7). Existing
+# hasSubjectList values on DaSCH are deleted (see check_values and
+# scripts/remove_subject_values.py).
 LIST_LABELS = {
-    "subject": {"Iconclass subject heading", "Iconclass Sachbegriff"},
     "temporal": {"Stadt.Geschichte.Basel Era", "Stadt.Geschichte.Basel Epoche"},
     "type": {"DCMI Type", "DCMI Type Vocabulary"},
     "format": {"Internet Media Type"},
@@ -77,13 +71,6 @@ def build_context() -> dict:
         ONTOLOGY_NAME: ONTOLOGY_CONTEXT,
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     }
-
-
-def apply_iconclass_subject(records: List[Dict[str, Any]]) -> None:
-    """Force test/sample records to use a known Iconclass subject label."""
-
-    for record in records:
-        record["dcterms:subject"] = [ICONCLASS_SUBJECT_ENTRY.copy()]
 
 
 # Set up logging
@@ -425,16 +412,13 @@ def check_values(dasch_item, omeka_item, lists):
     if description:
         modified_values.append(description)
 
-    subjects = []
-    for data in extract_combined_values(omeka_item.get("dcterms:subject", [])):
-        subject_iri = extract_listvalueiri_from_value(data, "subject", lists)
-        if subject_iri:
-            subjects.append(subject_iri)
+    # Subjects are not migrated (issue #7); delete any values written by
+    # earlier runs so DaSCH stays free of subject tags.
     subject = sync_array_value(
         "hasSubjectList",
         "ListValue",
         extract_dasch_propvalue_multiple(dasch_item, "hasSubjectList"),
-        subjects,
+        [],
     )
     if subject:
         modified_values.extend(subject)
@@ -715,19 +699,6 @@ def construct_payload(
             "knora-api:valueAsString": description_value,
             "@type": "knora-api:TextValue",
         }
-
-    subjects = []
-    for data in extract_combined_values(item.get("dcterms:subject", [])):
-        subject_iri = extract_listvalueiri_from_value(data, "subject", lists)
-        if subject_iri:
-            subjects.append(
-                {
-                    "@type": "knora-api:ListValue",
-                    "knora-api:listValueAsListNode": {"@id": subject_iri},
-                }
-            )
-    if subjects:
-        payload[f"{PREFIX}hasSubjectList"] = subjects
 
     temporal_iri = extract_listvalueiri_from_value(
         extract_property(item.get("dcterms:temporal", []), 41), "temporal", lists
@@ -1031,8 +1002,6 @@ def main() -> None:
     # Fetch item data
     items_data = get_items_from_collection(ITEM_SET_ID)
 
-    constrain_to_iconclass = args.mode in {"sample_data", "test_data"}
-
     if args.mode == "sample_data":
         items_data = random.sample(items_data, NUMBER_RANDOM_OBJECTS)
 
@@ -1049,9 +1018,6 @@ def main() -> None:
             if not remaining_identifiers:
                 break
         items_data = found_objects
-
-    if constrain_to_iconclass:
-        apply_iconclass_subject(items_data)
 
     # get_project()
     token = login(DSP_USER, DSP_PWD)
@@ -1075,8 +1041,6 @@ def main() -> None:
                 token, METADATA_RESOURCE_TYPE, item_id
             ).get("@id")
         media_data = get_media(item.get("o:id", ""))
-        if constrain_to_iconclass:
-            apply_iconclass_subject(media_data)
         if media_data:
             for media in media_data:
                 media_id = extract_property(media.get("dcterms:identifier", []), 10)

--- a/scripts/remove_subject_values.py
+++ b/scripts/remove_subject_values.py
@@ -1,0 +1,93 @@
+"""Delete all hasSubjectList values from DaSCH resources (issue #7).
+
+Subjects are no longer migrated (Iconclass classification was dropped for time
+and personnel reasons), but earlier sample/test runs wrote subject values to
+DaSCH. This one-off maintenance script removes them so DaSCH stays free of
+subject tags. Run with --dry-run first to see what would be deleted.
+"""
+
+import argparse
+import logging
+import urllib.parse
+
+import requests
+from data_2_dasch import (
+    API_HOST,
+    DEFAULT_TIMEOUT,
+    DSP_PWD,
+    DSP_USER,
+    MEDIA_RESOURCE_TYPES,
+    METADATA_RESOURCE_TYPE,
+    ONTOLOGY_CONTEXT,
+    PREFIX,
+    extract_dasch_propvalue_multiple,
+    get_full_resource,
+    login,
+    update_value,
+)
+
+
+def find_resources_with_subject(token: str, object_class: str) -> list:
+    """Return IRIs of resources of the given class that have a hasSubjectList value."""
+    query = f"""
+        PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+        PREFIX {PREFIX} <{ONTOLOGY_CONTEXT}>
+        CONSTRUCT {{
+            ?resource knora-api:isMainResource true .
+            ?resource {PREFIX}hasSubjectList ?subject .
+        }} WHERE {{
+            ?resource a {object_class} .
+            ?resource {PREFIX}hasSubjectList ?subject .
+        }}
+        """
+    response = requests.post(
+        f"{API_HOST}/v2/searchextended",
+        data=query.encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/sparql-query; charset=utf-8",
+        },
+        timeout=DEFAULT_TIMEOUT,
+    )
+    if response.status_code != 200:
+        logging.error(f"Search failed for {object_class}: {response.status_code}")
+        logging.error(response.text)
+        return []
+    result = response.json()
+    # A single hit comes back as the resource itself, multiple hits under @graph.
+    resources = result.get("@graph", [result] if "@id" in result else [])
+    return [resource["@id"] for resource in resources]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="only report which subject values would be deleted",
+    )
+    args = parser.parse_args()
+
+    token = login(DSP_USER, DSP_PWD)
+    total = 0
+    for object_class in [METADATA_RESOURCE_TYPE, *sorted(MEDIA_RESOURCE_TYPES)]:
+        for resource_iri in find_resources_with_subject(token, object_class):
+            resource = get_full_resource(
+                token, urllib.parse.quote(resource_iri, safe="")
+            )
+            for value in extract_dasch_propvalue_multiple(resource, "hasSubjectList"):
+                total += 1
+                if args.dry_run:
+                    logging.info(
+                        f"[dry-run] would delete hasSubjectList '{value}' "
+                        f"from {resource_iri}"
+                    )
+                else:
+                    update_value(
+                        token, resource, value, "hasSubjectList", "ListValue", "delete"
+                    )
+    logging.info(f"{'Found' if args.dry_run else 'Deleted'} {total} subject value(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/remove_subject_values.py
+++ b/scripts/remove_subject_values.py
@@ -28,35 +28,47 @@ from data_2_dasch import (
 
 
 def find_resources_with_subject(token: str, object_class: str) -> list:
-    """Return IRIs of resources of the given class that have a hasSubjectList value."""
-    query = f"""
-        PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
-        PREFIX {PREFIX} <{ONTOLOGY_CONTEXT}>
-        CONSTRUCT {{
-            ?resource knora-api:isMainResource true .
-            ?resource {PREFIX}hasSubjectList ?subject .
-        }} WHERE {{
-            ?resource a {object_class} .
-            ?resource {PREFIX}hasSubjectList ?subject .
-        }}
-        """
-    response = requests.post(
-        f"{API_HOST}/v2/searchextended",
-        data=query.encode("utf-8"),
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/sparql-query; charset=utf-8",
-        },
-        timeout=DEFAULT_TIMEOUT,
-    )
-    if response.status_code != 200:
-        logging.error(f"Search failed for {object_class}: {response.status_code}")
-        logging.error(response.text)
-        return []
-    result = response.json()
-    # A single hit comes back as the resource itself, multiple hits under @graph.
-    resources = result.get("@graph", [result] if "@id" in result else [])
-    return [resource["@id"] for resource in resources]
+    """Return IRIs of resources of the given class that have a hasSubjectList value.
+
+    Gravsearch results are paginated: OFFSET is the 0-based page index, and the
+    response carries knora-api:mayHaveMoreResults while further pages exist.
+    """
+    iris = []
+    offset = 0
+    while True:
+        query = f"""
+            PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+            PREFIX {PREFIX} <{ONTOLOGY_CONTEXT}>
+            CONSTRUCT {{
+                ?resource knora-api:isMainResource true .
+                ?resource {PREFIX}hasSubjectList ?subject .
+            }} WHERE {{
+                ?resource a {object_class} .
+                ?resource {PREFIX}hasSubjectList ?subject .
+            }}
+            OFFSET {offset}
+            """
+        response = requests.post(
+            f"{API_HOST}/v2/searchextended",
+            data=query.encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/sparql-query; charset=utf-8",
+            },
+            timeout=DEFAULT_TIMEOUT,
+        )
+        if response.status_code != 200:
+            logging.error(f"Search failed for {object_class}: {response.status_code}")
+            logging.error(response.text)
+            break
+        result = response.json()
+        # A single hit comes back as the resource itself, multiple hits under @graph.
+        resources = result.get("@graph", [result] if "@id" in result else [])
+        iris.extend(resource["@id"] for resource in resources)
+        if not result.get("knora-api:mayHaveMoreResults"):
+            break
+        offset += 1
+    return iris
 
 
 def main() -> None:
@@ -67,6 +79,12 @@ def main() -> None:
         help="only report which subject values would be deleted",
     )
     args = parser.parse_args()
+
+    # Stream-only logging; deliberately not data_2_dasch.setup_logging(), which
+    # would truncate the migration log.
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
 
     token = login(DSP_USER, DSP_PWD)
     total = 0

--- a/test/test_data_2_dasch.py
+++ b/test/test_data_2_dasch.py
@@ -8,8 +8,48 @@ Import path and environment come from conftest.py.
 from data_2_dasch import (
     PREFIX,
     build_text_or_uri_values,
+    extract_listvalueiri_from_value,
     sync_mixed_value_array,
 )
+
+# The DaSCH license list uses the license URL as the node label (see
+# data/data_model_dasch.json), and Omeka's dcterms:license @value is that same
+# URL, so the plain label lookup must resolve it to a list node IRI (issue #7).
+LICENSE_URLS = {
+    "https://creativecommons.org/publicdomain/mark/1.0/": "license_cc_pdm",
+    "https://creativecommons.org/publicdomain/zero/1.0/": "license_cc0",
+    "https://creativecommons.org/licenses/by/4.0/": "license_cc_by_4",
+    "https://creativecommons.org/licenses/by-sa/4.0/": "license_cc_by_sa_4",
+    "https://creativecommons.org/licenses/by-nc-sa/4.0/": "license_cc_by_nc_sa_4",
+    "http://rightsstatements.org/vocab/InC/1.0/": "license_in_c",
+    "http://rightsstatements.org/vocab/InC-RUU/1.0/": "license_in_c_ruu",
+}
+
+LICENSE_LIST_FIXTURE = [
+    {
+        "rdfs:label": "Licenses",
+        "knora-api:hasSubListNode": [
+            {"@id": f"http://rdfh.ch/lists/0123/{name}", "rdfs:label": url}
+            for url, name in LICENSE_URLS.items()
+        ],
+    }
+]
+
+
+def test_license_urls_resolve_to_list_node_iris():
+    """Each license URL from Omeka maps to a DaSCH list node IRI (issue #7)."""
+    for url, name in LICENSE_URLS.items():
+        iri = extract_listvalueiri_from_value(url, "license", LICENSE_LIST_FIXTURE)
+        assert iri == f"http://rdfh.ch/lists/0123/{name}", (
+            f"license URL '{url}' should resolve to node '{name}', got '{iri}'"
+        )
+
+
+def test_unknown_license_url_returns_none():
+    iri = extract_listvalueiri_from_value(
+        "https://example.com/not-a-license/", "license", LICENSE_LIST_FIXTURE
+    )
+    assert iri is None
 
 
 def test_prefix_definition():


### PR DESCRIPTION
Closes #7

## Summary

Resolves the two items that kept #7 open after #15.

### (1) `dcterms:license` — validated ✅

Omeka's `dcterms:license` `@value` is a license URL (e.g. `https://creativecommons.org/publicdomain/mark/1.0/`), and the DaSCH `license` list nodes use exactly those URLs as their labels — so the existing `extract_listvalueiri_from_value(..., "license", ...)` path already maps them to **`ListValue` node IRIs** (not free `UriValue`s). Now proven by:

- **Unit tests** covering all 7 license URLs from the data model plus the unknown-URL case.
- **Read-only live check** against the production DaSCH API (login + fetch lists only, no writes):

```
OK  https://creativecommons.org/publicdomain/mark/1.0/  -> http://rdfh.ch/lists/4001/g1txlRXPRZC6JvdGppLW1A
OK  https://creativecommons.org/publicdomain/zero/1.0/  -> http://rdfh.ch/lists/4001/z0IyZqx8QiO93IV9MQ3wEQ
OK  https://creativecommons.org/licenses/by/4.0/        -> http://rdfh.ch/lists/4001/9FPcn-DPSNuuT7vDUhqOgg
OK  https://creativecommons.org/licenses/by-sa/4.0/     -> http://rdfh.ch/lists/4001/YZWfgeoaS_yclOWf5F545Q
OK  https://creativecommons.org/licenses/by-nc-sa/4.0/  -> http://rdfh.ch/lists/4001/TTafIa4WQA2q9stXfPM2fQ
OK  http://rightsstatements.org/vocab/InC/1.0/          -> http://rdfh.ch/lists/4001/RrgizhbXTGabjYIZvZ0pjA
OK  http://rightsstatements.org/vocab/InC-RUU/1.0/      -> http://rdfh.ch/lists/4001/UjMRhCH9RMy-QsFxRZJW2g
```

### (2) `dcterms:subject` — Iconclass dropped, DaSCH kept free of subject tags

Decision: classifying all records with Iconclass will not be done due to time and personnel restrictions. Real Omeka subjects (customvocab:13 keywords like "Stadt") could never match the Iconclass list anyway and were silently dropped.

- `construct_payload` no longer writes `hasSubjectList`.
- `check_values` now emits **deletion-only** changes for `hasSubjectList`, so records updated by the regular sync are cleaned up.
- Removed the `ICONCLASS_SUBJECT_ENTRY` / `apply_iconclass_subject` fake-subject injection used by `sample_data`/`test_data` modes.
- New `scripts/remove_subject_values.py` (supports `--dry-run`): one-off cleanup that finds all resources with `hasSubjectList` values via gravsearch and deletes those values — needed because the regular sync only touches records whose Omeka `o:modified` is newer than the DaSCH date. **Not yet run against live**; run after merge.
- Documented the decision in `docs/datamodel`, `docs/guides/installation`, and the `docs/workflows` mapping diagram. The subject list and `hasSubjectList` property remain in the deployed ontology, just unpopulated (`data/data_model_dasch.json` unchanged).

## Test plan
- [x] `uv run --extra dev pytest test/ -v` — 16 passed (14 existing + 2 new license tests)
- [x] `uvx ruff check scripts/ test/` — clean
- [x] Read-only live license validation (output above)
- [ ] After merge: `python scripts/remove_subject_values.py --dry-run`, review, then run without `--dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subject values are no longer migrated into the platform, and existing subject lists can now be removed cleanly during maintenance runs.
  * List-value handling for license information has been improved.

* **Documentation**
  * Updated data model, installation, development, and workflow docs to reflect the current handling of subjects and related data transformations.

* **New Features**
  * Added a maintenance utility to report or delete stored subject list values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->